### PR TITLE
Extended get reporting functionality

### DIFF
--- a/searchads_api/api.py
+++ b/searchads_api/api.py
@@ -31,7 +31,7 @@ class SearchAdsAPI:
                  headers={},
                  json_data={},
                  params={},
-                 method="GET", 
+                 method="GET",
                  limit=1000,
                  offset=0):
         """
@@ -64,22 +64,19 @@ class SearchAdsAPI:
         kwargs["params"].update(params)
         api_endpoint = "{}/{}".format(self.api_version, api_endpoint)
         url = url.format(api_endpoint)
-        try:
-            if method == "get" or method == "GET":
-                req = caller.get(url, **kwargs)
-            elif method == "post" or method == "POST":
-                req = caller.post(url, **kwargs)
-            elif method == "put" or method == "PUT":
-                req = caller.put(url, **kwargs)
-            elif method == "delete" or method == "DELETE":
-                req = caller.delete(url, **kwargs)
-            if self.verbose:
-                print(req.url)
-                print(req.text)
-            return req.json()
-        except Exception as e:
-            print(str(e), url)
-            return None
+        req = None
+        if method == "get" or method == "GET":
+            req = caller.get(url, **kwargs)
+        elif method == "post" or method == "POST":
+            req = caller.post(url, **kwargs)
+        elif method == "put" or method == "PUT":
+            req = caller.put(url, **kwargs)
+        elif method == "delete" or method == "DELETE":
+            req = caller.delete(url, **kwargs)
+        if self.verbose and req:
+            print(req.url)
+            print(req.text)
+        return req.json()
 
     # Campaign Methods
     def create_campaign(self,
@@ -1444,7 +1441,7 @@ class SearchAdsAPI:
                 grandTotals.extend(
                     res["data"]["reportingDataResponse"]["grandTotals"])
             res_len = len(row)
-            
+
             offset = len(row)
                 # print(limit)
             if res_len == limit or res_len >= res["pagination"]["totalResults"]:

--- a/searchads_api/api.py
+++ b/searchads_api/api.py
@@ -76,6 +76,8 @@ class SearchAdsAPI:
         if self.verbose and req:
             print(req.url)
             print(req.text)
+        # Raising errors to show errors
+        req.raise_for_status()
         return req.json()
 
     # Campaign Methods

--- a/searchads_api/api.py
+++ b/searchads_api/api.py
@@ -186,6 +186,31 @@ class SearchAdsAPI:
             offset += result["pagination"]["itemsPerPage"]
         return res
 
+    def get_origins(self):
+        """
+        Get User ACL Response Example
+        {
+         "data": [
+         {
+         "currency": "USD",
+         "orgId": <OrgID>,
+         "orgName": "<OrgName1>",
+         "paymentModel": "LOC",
+         "roleNames": ["Admin"]
+         },
+         {
+         "currency": "USD",
+         "orgId": <OrgID>;,
+         "orgName": "<OrgName2>",
+         "paymentModel": "LOC",
+         "roleNames": ["Admin"]
+         }],
+        }
+        """
+        return self.api_call(
+            api_endpoint="acls"
+        )
+
     def update_campaign(self,
                         campaign_id,
                         countries=None,

--- a/searchads_api/api.py
+++ b/searchads_api/api.py
@@ -88,7 +88,7 @@ class SearchAdsAPI:
                         campaign_name,
                         budget,
                         daily_budget,
-                        curruncy):
+                        currency):
         """
         Creates a campaign to promote an app.
         """
@@ -97,11 +97,11 @@ class SearchAdsAPI:
             "name": campaign_name,
             "budgetAmount": {
                 "amount": "{}".format(budget),
-                "currency": curruncy
+                "currency": currency
             },
             "dailyBudgetAmount": {
                 "amount": "{}".format(daily_budget),
-                "currency": curruncy
+                "currency": currency
             },
             "adamId": app_id,
             "countriesOrRegions": countries
@@ -1304,7 +1304,8 @@ class SearchAdsAPI:
                                     return_row_totals=True,
                                     return_grand_totals=True,
                                     offset=0,
-                                    limit=1000):
+                                    limit=1000,
+                                    **kwargs):
         """
         Get reports on targeting keywords within a specific campaign.
         """

--- a/searchads_api/api.py
+++ b/searchads_api/api.py
@@ -1146,7 +1146,8 @@ class SearchAdsAPI:
                                      return_row_totals=True,
                                      return_grand_totals=True,
                                      offset=0,
-                                     limit=1000):
+                                     limit=1000,
+                                     **kwargs):
         """
         Get reports on campaigns within a specific org.
         {
@@ -1206,7 +1207,8 @@ class SearchAdsAPI:
                               return_row_totals=return_row_totals,
                               return_grand_totals=return_grand_totals,
                               offset=offset,
-                              limit=limit)
+                              limit=limit,
+                              **kwargs)
 
     def get_adgroups_report_by_date(self,
                                     campaignId,
@@ -1219,7 +1221,8 @@ class SearchAdsAPI:
                                     return_row_totals=True,
                                     return_grand_totals=True,
                                     offset=0,
-                                    limit=1000):
+                                    limit=1000,
+                                    **kwargs):
         """
         Get reports on adGroups within a specific campaign.
         {
@@ -1261,7 +1264,8 @@ class SearchAdsAPI:
                               return_row_totals=return_row_totals,
                               return_grand_totals=return_grand_totals,
                               offset=offset,
-                              limit=limit)
+                              limit=limit,
+                              **kwargs)
 
     def get_creativesets_report_by_date(self,
                                         campaignId,
@@ -1274,7 +1278,8 @@ class SearchAdsAPI:
                                         return_row_totals=True,
                                         return_grand_totals=True,
                                         offset=0,
-                                        limit=1000):
+                                        limit=1000,
+                                        **kwargs):
         """
         Fetches reports on Creative Sets used within a campaign.
         conditions example
@@ -1291,7 +1296,8 @@ class SearchAdsAPI:
                               return_row_totals=return_row_totals,
                               return_grand_totals=return_grand_totals,
                               offset=offset,
-                              limit=limit)
+                              limit=limit,
+                              **kwargs)
 
     def get_keywords_report_by_date(self,
                                     campaignId,
@@ -1320,7 +1326,8 @@ class SearchAdsAPI:
                               return_row_totals=return_row_totals,
                               return_grand_totals=return_grand_totals,
                               offset=offset,
-                              limit=limit)
+                              limit=limit,
+                              **kwargs)
 
     def get_searchterms_report_by_date(self,
                                        campaignId,
@@ -1333,7 +1340,8 @@ class SearchAdsAPI:
                                        return_row_totals=True,
                                        return_grand_totals=True,
                                        offset=0,
-                                       limit=1000):
+                                       limit=1000,
+                                       **kwargs):
         """
         Get reports on targeting keywords within a specific campaign.
         """
@@ -1348,7 +1356,8 @@ class SearchAdsAPI:
                               return_row_totals=return_row_totals,
                               return_grand_totals=return_grand_totals,
                               offset=offset,
-                              limit=limit)
+                              limit=limit,
+                              **kwargs)
 
     def _get_data(self,
                   data_type,
@@ -1363,7 +1372,8 @@ class SearchAdsAPI:
                   offset,
                   limit,
                   campaignId=None,
-                  group_by=None):
+                  group_by=None,
+                  **kwargs):
         row = []
         grandTotals = []
         if limit == 0:
@@ -1396,6 +1406,12 @@ class SearchAdsAPI:
                 data["groupBy"] = [
                     group_by
                 ]
+            if kwargs:
+                data = {
+                    **data,
+                    **kwargs
+                }
+
             if data_type == "campaigns":
                 res = self.api_call("reports/campaigns",
                                     json_data=data, method="POST")


### PR DESCRIPTION
- Fixed typo
- Added ability to set new properties like "granularity" and "fields" in get-reports functionality

I'm not sure if these fields were added in SearchAds V3 API but there are unhandled properties in :
- ReportingRequest object https://developer.apple.com/documentation/apple_search_ads/reportingrequest (granularity)
- Selector object https://developer.apple.com/documentation/apple_search_ads/selector (fields)

This PR will allow adding these properties to the request